### PR TITLE
remove unused symfony/options-resolver dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
         "php-http/client-common": "^1.6",
         "php-http/cache-plugin": "^1.4",
         "php-http/logger-plugin": "^1.0",
-        "ramsey/uuid": "^3.0",
-        "symfony/options-resolver": "^2.8"
+        "ramsey/uuid": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7"


### PR DESCRIPTION
This dependency blocks ability to use the API client in newer versions of Symfony (>= 3.0) and I don't event see where OptionsResolver is used in project. It seems to be a useless dependency.